### PR TITLE
update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,20 +40,20 @@
     "async": "~0.2.9",
     "buffered-spawn": "~1.1.2",
     "chalk": "~1.1.1",
-    "commander": "~2.1.0",
-    "commander-completion": "~0.1.0",
-    "deep-equal": "~1.0.1",
+    "commander": "~2.20.3",
+    "commander-completion": "~0.5.0",
+    "deep-equal": "~1.1.0",
     "underscore": "~1.13.1"
   },
   "devDependencies": {
-    "chai": "~1.8.1",
-    "eslint": "~4.10.0",
+    "chai": "~1.10.0",
+    "eslint": "~4.19.1",
     "eslint-config-twolfson": "~1.0.0",
-    "foundry": "~4.2.0",
+    "foundry": "~4.5.0",
     "foundry-release-base": "~1.0.1",
-    "foundry-release-git": "~2.0.1",
+    "foundry-release-git": "~2.0.4",
     "foundry-release-npm": "~2.0.1",
-    "mocha": "~2.3.3",
+    "mocha": "~8.4.0",
     "stream-buffers": "~2.2.0"
   },
   "keywords": [


### PR DESCRIPTION
Update the other dependencies (besides underscore).
This should probably have been part of the previous PR https://github.com/twolfson/foundry/pull/29, but somehow I was only focused on the `underscore` package there. Sorry for the extra work.

While the update of `commander-completion` from `0.1.0` to `0.5.0` _could in theory be a breaking change_, the tests still run and pass. So I guess it is still alright. (Newest version of `commander-completion` is 1.0.1, but any 1.0.x version seems to break the tests - at least on my local machine.)